### PR TITLE
#10 removed annotation  kustomize.toolkit.fluxcd.io/prune

### DIFF
--- a/dev/example-workspace-20240516/bindings.yaml
+++ b/dev/example-workspace-20240516/bindings.yaml
@@ -2,8 +2,6 @@ apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspaceBinding
 metadata:
   name: example-workspace-20240516-shaun-turner
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   workspace: example-workspace-20240516
   username: "shaun.turner1@nhs.net"

--- a/dev/example-workspace-20240516/workspace.yaml
+++ b/dev/example-workspace-20240516/workspace.yaml
@@ -2,8 +2,6 @@ apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspace
 metadata:
   name: example-workspace-20240516
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   displayName: Example workspace - 2024-05-16
   description: |

--- a/dev/example-workspace-20240716/bindings.yaml
+++ b/dev/example-workspace-20240716/bindings.yaml
@@ -2,8 +2,6 @@ apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspaceBinding
 metadata:
   name: example-workspace-20240716-shaun-turner
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   workspace: example-workspace-20240716
   username: "shaun.turner1@nhs.net"

--- a/dev/example-workspace-20240716/workspace.yaml
+++ b/dev/example-workspace-20240716/workspace.yaml
@@ -2,8 +2,6 @@ apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspace
 metadata:
   name: example-workspace-20240716
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   displayName: Example workspace - 2024-07-16
   description: |

--- a/dev/mph-omop-workspace/bindings.yaml
+++ b/dev/mph-omop-workspace/bindings.yaml
@@ -2,8 +2,6 @@ apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspaceBinding
 metadata:
   name: mph-omop-workspace-vishnu-chandrabalan
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   workspace: mph-omop-workspace
   username: "vishnu.chandrabalan@lthtr.nhs.uk"
@@ -13,8 +11,6 @@ apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspaceBinding
 metadata:
   name: mph-omop-workspace-mike-harding
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   workspace: mph-omop-workspace
   username: "m.harding@lancaster.ac.uk"
@@ -24,8 +20,6 @@ apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspaceBinding
 metadata:
   name: metrics-test-workspace-mike-harding
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   workspace: metrics-test-workspace
   username: "m.harding@lancaster.ac.uk"
@@ -35,8 +29,6 @@ apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspaceBinding
 metadata:
   name: metrics-test-workspace-shaun-turner
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   workspace: metrics-test-workspace
   username: "shaun.turner1@nhs.net"

--- a/dev/mph-omop-workspace/workspace.yaml
+++ b/dev/mph-omop-workspace/workspace.yaml
@@ -2,8 +2,6 @@ apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspace
 metadata:
   name: mph-omop-workspace
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   displayName: DARWIN Workspace
   description: |
@@ -22,8 +20,6 @@ apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspace
 metadata:
   name: metrics-test-workspace
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   displayName: Metrics Test Workspace
   description: |

--- a/dev/ohdsi-conf-darwin-workspace/bindings.yaml
+++ b/dev/ohdsi-conf-darwin-workspace/bindings.yaml
@@ -2,8 +2,6 @@ apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspaceBinding
 metadata:
   name: ohdsi-conf-workspace-vishnu-chandrabalan
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   workspace: ohdsi-conf-workspace
   username: "vishnu.chandrabalan@lthtr.nhs.uk"
@@ -13,8 +11,6 @@ apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspaceBinding
 metadata:
   name: ohdsi-conf-workspace-mike-harding
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   workspace: ohdsi-conf-workspace
   username: "m.harding@lancaster.ac.uk"
@@ -24,8 +20,6 @@ apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspaceBinding
 metadata:
   name: ohdsi-conf-workspace-quinta-ashcroft
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   workspace: ohdsi-conf-workspace
   username: "quinta.ashcroft@lthtr.nhs.uk"
@@ -35,8 +29,6 @@ apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspaceBinding
 metadata:
   name: ohdsi-conf-workspace-timothy-howcroft
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   workspace: ohdsi-conf-workspace
   username: "timothy.howcroft@lthtr.nhs.uk"

--- a/dev/ohdsi-conf-darwin-workspace/workspace.yaml
+++ b/dev/ohdsi-conf-darwin-workspace/workspace.yaml
@@ -2,8 +2,6 @@ apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspace
 metadata:
   name: ohdsi-conf-workspace
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   displayName: OHDSI Conference Workspace
   description: |

--- a/production/arcnwc-chi-se419/bindings.yaml
+++ b/production/arcnwc-chi-se419/bindings.yaml
@@ -2,8 +2,6 @@ apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspaceBinding
 metadata:
   name: arcnwc-chi-se419-vishnu-chandrabalan
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   workspace: arcnwc-chi-se419
   username: "vishnu.chandrabalan@lthtr.nhs.uk"
@@ -13,8 +11,6 @@ apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspaceBinding
 metadata:
   name: arcnwc-chi-se419-konstantinos-daras
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   workspace: arcnwc-chi-se419
   username: "konstantinos.daras@lthtr.nhs.uk"
@@ -24,8 +20,6 @@ apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspaceBinding
 metadata:
   name: arcnwc-chi-se419-olly-butters
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   workspace: arcnwc-chi-se419
   username: "olly.butters@lthtr.nhs.uk"
@@ -35,8 +29,6 @@ apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspaceBinding
 metadata:
   name: arcnwc-chi-se419-pieta-schofield
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   workspace: arcnwc-chi-se419
   username: "pieta.schofield@lthtr.nhs.uk"
@@ -46,8 +38,6 @@ apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspaceBinding
 metadata:
   name: arcnwc-chi-se419-roberto-villegas-diaz
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   workspace: arcnwc-chi-se419
   username: "roberto.villegas-diaz@lthtr.nhs.uk"

--- a/production/arcnwc-chi-se419/workspace.yaml
+++ b/production/arcnwc-chi-se419/workspace.yaml
@@ -2,8 +2,6 @@ apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspace
 metadata:
   name: arcnwc-chi-se419
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   displayName: ARCNWC-CHI-SE419
   description: |

--- a/production/arcnwc-chi-se421/bindings.yaml
+++ b/production/arcnwc-chi-se421/bindings.yaml
@@ -2,8 +2,6 @@ apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspaceBinding
 metadata:
   name: arcnwc-chi-se421-vishnu-chandrabalan
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   workspace: arcnwc-chi-se421
   username: "vishnu.chandrabalan@lthtr.nhs.uk"
@@ -13,8 +11,6 @@ apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspaceBinding
 metadata:
   name: arcnwc-chi-se421-konstantinos-daras
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   workspace: arcnwc-chi-se421
   username: "konstantinos.daras@lthtr.nhs.uk"
@@ -24,8 +20,6 @@ apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspaceBinding
 metadata:
   name: arcnwc-chi-se421-olly-butters
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   workspace: arcnwc-chi-se421
   username: "olly.butters@lthtr.nhs.uk"
@@ -35,8 +29,6 @@ apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspaceBinding
 metadata:
   name: arcnwc-chi-se421-pieta-schofield
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   workspace: arcnwc-chi-se421
   username: "pieta.schofield@lthtr.nhs.uk"
@@ -46,8 +38,6 @@ apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspaceBinding
 metadata:
   name: arcnwc-chi-se421-roberto-villegas-diaz
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   workspace: arcnwc-chi-se421
   username: "roberto.villegas-diaz@lthtr.nhs.uk"

--- a/production/arcnwc-chi-se421/workspace.yaml
+++ b/production/arcnwc-chi-se421/workspace.yaml
@@ -2,8 +2,6 @@ apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspace
 metadata:
   name: arcnwc-chi-se421
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   displayName: ARCNWC-CHI-SE421
   description: |

--- a/production/avoidable-admissions/bindings.yaml
+++ b/production/avoidable-admissions/bindings.yaml
@@ -2,8 +2,6 @@ apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspaceBinding
 metadata:
   name: avoidable-admissions-vishnu-chandrabalan
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   workspace: avoidable-admissions
   username: "vishnu.chandrabalan@lthtr.nhs.uk"
@@ -14,7 +12,7 @@ kind: AnalyticsWorkspaceBinding
 metadata:
   name: avoidable-admissions-alex-garner
   annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
+    
 spec:
   workspace: avoidable-admissions
   username: "alex.garner@lthtr.nhs.uk"
@@ -24,8 +22,6 @@ apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspaceBinding
 metadata:
   name: avoidable-admissions-jo-knight
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   workspace: avoidable-admissions
   username: "jo.knight@lthtr.nhs.uk"
@@ -35,8 +31,6 @@ apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspaceBinding
 metadata:
   name: avoidable-admissions-quinta-ashcroft
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   workspace: avoidable-admissions
   username: "quinta.ashcroft@lthtr.nhs.uk"

--- a/production/avoidable-admissions/workspace.yaml
+++ b/production/avoidable-admissions/workspace.yaml
@@ -2,8 +2,6 @@ apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspace
 metadata:
   name: avoidable-admissions
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   displayName: Avoidable Admissions
   description: |

--- a/production/diabetic-foot-ulcer-research/bindings.yaml
+++ b/production/diabetic-foot-ulcer-research/bindings.yaml
@@ -2,8 +2,6 @@ apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspaceBinding
 metadata:
   name: diabetic-foot-ulcer-research-vishnu-chandrabalan
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   workspace: diabetic-foot-ulcer-research
   username: "vishnu.chandrabalan@lthtr.nhs.uk"
@@ -13,8 +11,6 @@ apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspaceBinding
 metadata:
   name: diabetic-foot-ulcer-research-bill-cassidy
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   workspace: diabetic-foot-ulcer-research
   username: "bill.cassidy@lthtr.nhs.uk"
@@ -24,8 +20,6 @@ apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspaceBinding
 metadata:
   name: diabetic-foot-ulcer-research-moihoon-yap
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   workspace: diabetic-foot-ulcer-research
   username: "moihoon.yap@lthtr.nhs.uk"
@@ -35,8 +29,6 @@ apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspaceBinding
 metadata:
   name: diabetic-foot-ulcer-research-quinta-ashcroft
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   workspace: diabetic-foot-ulcer-research
   username: "quinta.ashcroft@lthtr.nhs.uk"
@@ -46,8 +38,6 @@ apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspaceBinding
 metadata:
   name: diabetic-foot-ulcer-research-shaghayegh-raad
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   workspace: diabetic-foot-ulcer-research
   username: "shaghayegh.raad@lthtr.nhs.uk"
@@ -57,8 +47,6 @@ apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspaceBinding
 metadata:
   name: diabetic-foot-ulcer-research-timothy-howcroft
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   workspace: diabetic-foot-ulcer-research
   username: "timothy.howcroft@lthtr.nhs.uk"

--- a/production/diabetic-foot-ulcer-research/workspace.yaml
+++ b/production/diabetic-foot-ulcer-research/workspace.yaml
@@ -2,8 +2,6 @@ apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspace
 metadata:
   name: diabetic-foot-ulcer-research
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   displayName: Diabetic Foot Ulcer Research
   description: |

--- a/production/llm-workspace/bindings.yaml
+++ b/production/llm-workspace/bindings.yaml
@@ -2,8 +2,6 @@ apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspaceBinding
 metadata:
   name: llm-workspace-vishnu-chandrabalan
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   workspace: llm-workspace
   username: "vishnu.chandrabalan@lthtr.nhs.uk"
@@ -13,8 +11,6 @@ apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspaceBinding
 metadata:
   name: llm-workspace-stephen-dobson
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   workspace: llm-workspace
   username: "stephen.dobson@lthtr.nhs.uk"
@@ -24,8 +20,6 @@ apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspaceBinding
 metadata:
   name: llm-workspace-zhangshu-jiang
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   workspace: llm-workspace
   username: "zhangshu.jiang@lthtr.nhs.uk"

--- a/production/llm-workspace/workspace.yaml
+++ b/production/llm-workspace/workspace.yaml
@@ -2,8 +2,6 @@ apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspace
 metadata:
   name: llm-workspace
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   displayName: LLM Workspace
   description: |

--- a/production/lsc-maternity-workspace/bindings.yaml
+++ b/production/lsc-maternity-workspace/bindings.yaml
@@ -2,8 +2,6 @@ apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspaceBinding
 metadata:
   name: lsc-maternity-workspace-vishnu-chandrabalan
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   workspace: lsc-maternity-workspace
   username: "vishnu.chandrabalan@lthtr.nhs.uk"
@@ -13,8 +11,6 @@ apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspaceBinding
 metadata:
   name: lsc-maternity-workspace-gillian-byrne
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   workspace: lsc-maternity-workspace
   username: "gillian.byrne@lthtr.nhs.uk"

--- a/production/lsc-maternity-workspace/workspace.yaml
+++ b/production/lsc-maternity-workspace/workspace.yaml
@@ -2,8 +2,6 @@ apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspace
 metadata:
   name: lsc-maternity-workspace
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   displayName: LSC Maternity Analytics
   description: |

--- a/production/lth-data-science-team-workspace/bindings.yaml
+++ b/production/lth-data-science-team-workspace/bindings.yaml
@@ -2,8 +2,6 @@ apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspaceBinding
 metadata:
   name: lth-data-science-team-workspace-vishnu-chandrabalan
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   workspace: lth-data-science-team-workspace
   username: "vishnu.chandrabalan@lthtr.nhs.uk"
@@ -13,8 +11,6 @@ apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspaceBinding
 metadata:
   name: lth-data-science-team-workspace-andrew-robinson
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   workspace: lth-data-science-team-workspace
   username: "andrew.robinson@lthtr.nhs.uk"
@@ -24,8 +20,6 @@ apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspaceBinding
 metadata:
   name: lth-data-science-team-workspace-quinta-ashcroft
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   workspace: lth-data-science-team-workspace
   username: "quinta.ashcroft@lthtr.nhs.uk"
@@ -35,8 +29,6 @@ apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspaceBinding
 metadata:
   name: lth-data-science-team-workspace-stephen-dobson
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   workspace: lth-data-science-team-workspace
   username: "stephen.dobson@lthtr.nhs.uk"
@@ -46,8 +38,6 @@ apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspaceBinding
 metadata:
   name: lth-data-science-team-workspace-timothy-howcroft
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   workspace: lth-data-science-team-workspace
   username: "timothy.howcroft@lthtr.nhs.uk"

--- a/production/lth-data-science-team-workspace/workspace.yaml
+++ b/production/lth-data-science-team-workspace/workspace.yaml
@@ -2,8 +2,6 @@ apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspace
 metadata:
   name: lth-data-science-team-workspace
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   displayName: LTH Data Science Team Workspace
   description: |

--- a/production/lth-finance-workspace/bindings.yaml
+++ b/production/lth-finance-workspace/bindings.yaml
@@ -2,8 +2,6 @@ apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspaceBinding
 metadata:
   name: lth-finance-workspace-vishnu-chandrabalan
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   workspace: lth-finance-workspace
   username: "vishnu.chandrabalan@lthtr.nhs.uk"
@@ -13,8 +11,6 @@ apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspaceBinding
 metadata:
   name: lth-finance-workspace-stephen-dobson
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   workspace: lth-finance-workspace
   username: "stephen.dobson@lthtr.nhs.uk"
@@ -24,8 +20,6 @@ apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspaceBinding
 metadata:
   name: lth-finance-workspace-ellenor-forsyth
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   workspace: lth-finance-workspace
   username: "ellenor.forsyth@lthtr.nhs.uk"

--- a/production/lth-finance-workspace/workspace.yaml
+++ b/production/lth-finance-workspace/workspace.yaml
@@ -2,8 +2,6 @@ apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspace
 metadata:
   name: lth-finance-workspace
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   displayName: LTH Finance Workspace
   description: |

--- a/production/lth-ugi-surgery-generic-workspace/bindings.yaml
+++ b/production/lth-ugi-surgery-generic-workspace/bindings.yaml
@@ -3,8 +3,6 @@ apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspaceBinding
 metadata:
   name: lth-ugi-surgery-generic-workspace-vishnu-chandrabalan
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   workspace: lth-ugi-surgery-generic-workspace
   username: "vishnu.chandrabalan@lthtr.nhs.uk"
@@ -14,8 +12,6 @@ apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspaceBinding
 metadata:
   name: lth-ugi-surgery-generic-workspace-david-larkin
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   workspace: lth-ugi-surgery-generic-workspace
   username: "david.larkin@lthtr.nhs.uk"

--- a/production/lth-ugi-surgery-generic-workspace/workspace.yaml
+++ b/production/lth-ugi-surgery-generic-workspace/workspace.yaml
@@ -2,8 +2,6 @@ apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspace
 metadata:
   name: lth-ugi-surgery-generic-workspace
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   displayName: LTH UGI Surgery Generic Workspace
   description: |

--- a/production/neurosurgery-generic-workspace/bindings.yaml
+++ b/production/neurosurgery-generic-workspace/bindings.yaml
@@ -2,8 +2,6 @@ apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspaceBinding
 metadata:
   name: neurosurgery-generic-workspace-vishnu-chandrabalan
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   workspace: neurosurgery-generic-workspace
   username: "vishnu.chandrabalan@lthtr.nhs.uk"
@@ -13,8 +11,6 @@ apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspaceBinding
 metadata:
   name: neurosurgery-generic-workspace-frazer-obrien
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   workspace: neurosurgery-generic-workspace
   username: "frazer.o'brien@lthtr.nhs.uk"

--- a/production/neurosurgery-generic-workspace/workspace.yaml
+++ b/production/neurosurgery-generic-workspace/workspace.yaml
@@ -2,8 +2,6 @@ apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspace
 metadata:
   name: neurosurgery-generic-workspace
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   displayName: Neurosurgery Generic Workspace
   description: |

--- a/production/nihr-lcrf-workspace/bindings.yaml
+++ b/production/nihr-lcrf-workspace/bindings.yaml
@@ -2,8 +2,6 @@ apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspaceBinding
 metadata:
   name: nihr-lcrf-workspace-vishnu-chandrabalan
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   workspace: nihr-lcrf-workspace
   username: "vishnu.chandrabalan@lthtr.nhs.uk"
@@ -13,8 +11,6 @@ apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspaceBinding
 metadata:
   name: nihr-lcrf-workspace-catherine-neary
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   workspace: nihr-lcrf-workspace
   username: "catherine.neary@lthtr.nhs.uk"

--- a/production/nihr-lcrf-workspace/workspace.yaml
+++ b/production/nihr-lcrf-workspace/workspace.yaml
@@ -2,8 +2,6 @@ apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspace
 metadata:
   name: nihr-lcrf-workspace
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   displayName: NIHR Lancashire Clinical Research Facility Workspace
   description: |

--- a/production/uhmb-generic-workspace/bindings.yaml
+++ b/production/uhmb-generic-workspace/bindings.yaml
@@ -2,8 +2,6 @@ apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspaceBinding
 metadata:
   name: uhmb-generic-workspace-vishnu-chandrabalan
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   workspace: uhmb-generic-workspace
   username: "vishnu.chandrabalan@lthtr.nhs.uk"
@@ -13,8 +11,6 @@ apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspaceBinding
 metadata:
   name: uhmb-generic-workspace-kelly-heys
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   workspace: uhmb-generic-workspace
   username: "kelly.heys@mbhci.nhs.uk"
@@ -24,8 +20,6 @@ apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspaceBinding
 metadata:
   name: uhmb-generic-workspace-catherine-jones
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   workspace: uhmb-generic-workspace
   username: "catherine.jones@mbhci.nhs.uk"
@@ -35,8 +29,6 @@ apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspaceBinding
 metadata:
   name: uhmb-generic-workspace-dale-wright
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   workspace: uhmb-generic-workspace
   username: "dale.wright@mbhci.nhs.uk"

--- a/production/uhmb-generic-workspace/workspace.yaml
+++ b/production/uhmb-generic-workspace/workspace.yaml
@@ -2,8 +2,6 @@ apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspace
 metadata:
   name: uhmb-generic-workspace
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   displayName: UHMB Generic Workspace
   description: |

--- a/production/uom-antimicrobial-workspace/bindings.yaml
+++ b/production/uom-antimicrobial-workspace/bindings.yaml
@@ -2,8 +2,6 @@ apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspaceBinding
 metadata:
   name: uom-antimicrobial-workspace-vishnu-chandrabalan
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   workspace: uom-antimicrobial-workspace
   username: "vishnu.chandrabalan@lthtr.nhs.uk"
@@ -13,8 +11,6 @@ apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspaceBinding
 metadata:
   name: uom-antimicrobial-workspace-yuan-tian
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   workspace: uom-antimicrobial-workspace
   username: "yuan.tian@lthtr.nhs.uk"
@@ -24,8 +20,6 @@ apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspaceBinding
 metadata:
   name: uom-antimicrobial-workspace-amani-albalushi
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   workspace: uom-antimicrobial-workspace
   username: "amani.albalushi@lthtr.nhs.uk"
@@ -35,8 +29,6 @@ apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspaceBinding
 metadata:
   name: uom-antimicrobial-workspace-yuki-wang
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   workspace: uom-antimicrobial-workspace
   username: "yuqi.wang@lthtr.nhs.uk"
@@ -46,8 +38,6 @@ apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspaceBinding
 metadata:
   name: uom-antimicrobial-workspace-timothy-howcroft
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   workspace: uom-antimicrobial-workspace
   username: "timothy.howcroft@lthtr.nhs.uk"
@@ -57,8 +47,6 @@ apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspaceBinding
 metadata:
   name: uom-antimicrobial-workspace-quinta-ashcroft
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   workspace: uom-antimicrobial-workspace
   username: "quinta.ashcroft@lthtr.nhs.uk"

--- a/production/uom-antimicrobial-workspace/workspace.yaml
+++ b/production/uom-antimicrobial-workspace/workspace.yaml
@@ -2,8 +2,6 @@ apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspace
 metadata:
   name: uom-antimicrobial-workspace
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   displayName: Antimicrobial Prescribing Research
   description: |

--- a/production/vc-sd-workspace/bindings.yaml
+++ b/production/vc-sd-workspace/bindings.yaml
@@ -2,8 +2,6 @@ apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspaceBinding
 metadata:
   name: vc-sd-workspace-vishnu-chandrabalan
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   workspace: vc-sd-workspace
   username: "vishnu.chandrabalan@lthtr.nhs.uk"
@@ -13,8 +11,6 @@ apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspaceBinding
 metadata:
   name: vc-sd-workspace-stephen-dobson
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   workspace: vc-sd-workspace
   username: "stephen.dobson@lthtr.nhs.uk"

--- a/production/vc-sd-workspace/workspace.yaml
+++ b/production/vc-sd-workspace/workspace.yaml
@@ -2,8 +2,6 @@ apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspace
 metadata:
   name: vc-sd-workspace
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   displayName: VC-SD Workspace
   description: |

--- a/sandbox/example-workspace-20240516/bindings.yaml
+++ b/sandbox/example-workspace-20240516/bindings.yaml
@@ -2,8 +2,6 @@ apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspaceBinding
 metadata:
   name: example-workspace-20240516-shaun-turner
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   workspace: example-workspace-20240516
   username: "shaun.turner1@nhs.net"

--- a/sandbox/example-workspace-20240516/workspace.yaml
+++ b/sandbox/example-workspace-20240516/workspace.yaml
@@ -2,8 +2,6 @@ apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspace
 metadata:
   name: example-workspace-20240516
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   displayName: Example workspace - 2024-05-16
   description: |

--- a/shared/advanced-generic-workspace/bindings.yaml
+++ b/shared/advanced-generic-workspace/bindings.yaml
@@ -2,8 +2,6 @@ apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspaceBinding
 metadata:
   name: advanced-generic-workspace-shaun-turner
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   workspace: advanced-generic-workspace
   username: "shaun.turner1@nhs.net"
@@ -13,8 +11,6 @@ apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspaceBinding
 metadata:
   name: advanced-generic-workspace-vishnu-chandrabalan
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   workspace: advanced-generic-workspace
   username: "vishnu.chandrabalan@lthtr.nhs.uk"

--- a/shared/advanced-generic-workspace/workspace.yaml
+++ b/shared/advanced-generic-workspace/workspace.yaml
@@ -2,8 +2,6 @@ apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspace
 metadata:
   name: advanced-generic-workspace
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   displayName: Advanced Generic Workspace
   description: |

--- a/shared/default-generic-workspace/bindings.yaml
+++ b/shared/default-generic-workspace/bindings.yaml
@@ -2,8 +2,6 @@ apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspaceBinding
 metadata:
   name: default-generic-workspace-shaun-turner
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   workspace: default-generic-workspace
   username: "shaun.turner1@nhs.net"
@@ -13,8 +11,6 @@ apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspaceBinding
 metadata:
   name: default-generic-workspace-vishnu-chandrabalan
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   workspace: default-generic-workspace
   username: "vishnu.chandrabalan@lthtr.nhs.uk"

--- a/shared/default-generic-workspace/workspace.yaml
+++ b/shared/default-generic-workspace/workspace.yaml
@@ -2,8 +2,6 @@ apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspace
 metadata:
   name: default-generic-workspace
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   displayName: Default Generic Workspace
   description: |

--- a/shared/smoke-tests/smoke-test-001/bindings.yaml
+++ b/shared/smoke-tests/smoke-test-001/bindings.yaml
@@ -2,8 +2,6 @@ apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspaceBinding
 metadata:
   name: smoke-test-001-vishnu-chandrabalan
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   workspace: smoke-test-001
   username: "vishnu.chandrabalan@lthtr.nhs.uk"
@@ -13,8 +11,6 @@ apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspaceBinding
 metadata:
   name: smoke-test-001-shaun-turner
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   workspace: smoke-test-001
   username: "shaun.turner1@nhs.net"

--- a/shared/smoke-tests/smoke-test-001/workspace.yaml
+++ b/shared/smoke-tests/smoke-test-001/workspace.yaml
@@ -2,8 +2,6 @@ apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspace
 metadata:
   name: smoke-test-001
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   displayName: Smoke Test 001
   description: |

--- a/staging/datascience-large/bindings.yaml
+++ b/staging/datascience-large/bindings.yaml
@@ -2,8 +2,6 @@ apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspaceBinding
 metadata:
   name: datascience-large-vishnu-chandrabalan
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   workspace: datascience-large
   username: "vishnu.chandrabalan@lthtr.nhs.uk"
@@ -13,8 +11,6 @@ apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspaceBinding
 metadata:
   name: datascience-large-shaun-turner
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   workspace: datascience-large
   username: "shaun.turner1@nhs.net"

--- a/staging/datascience-large/workspace.yaml
+++ b/staging/datascience-large/workspace.yaml
@@ -2,8 +2,6 @@ apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspace
 metadata:
   name: datascience-large
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   displayName: Large Datascience Notebook
   description: |


### PR DESCRIPTION
Removed annotation kustomize.toolkit.fluxcd.io/prune to allow pruning to occur on all resources. This will need to be followed up with the following commands being run against the various environments manually:

```bash
kubectl label analyticsworkspace --all -A kustomize.toolkit.fluxcd.io/prune-
kubectl label analyticsworkspacebinding --all -A kustomize.toolkit.fluxcd.io/prune-
```